### PR TITLE
Include dependencies in the global build

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,12 +7,16 @@ stealTools.export({
 	outputs: {
 		"+cjs": {},
 		"+amd": {},
-		"+global-js": {}
+		"+standalone": {
+			exports: {
+				"can-namespace": "can"
+			}
+		}
 	}
 }).catch(function(e){
-	
+
 	setTimeout(function(){
 		throw e;
 	}, 1);
-	
+
 });


### PR DESCRIPTION
Now, when the global file is included in a `<script>`, `window.can.ndjsonStream` will be available.