### PR TITLE
Catch error from stream reader

### DIFF
--- a/can-ndjson-stream.js
+++ b/can-ndjson-stream.js
@@ -12,6 +12,7 @@ var ndjsonStream = function(response) {
       is_reader = reader;
       var decoder = new TextDecoder();
       var data_buf = "";
+      var errorHandler = controller.error.bind(controller);
 
       reader.read().then(function processResult(result) {
         if (result.done) {
@@ -53,8 +54,8 @@ var ndjsonStream = function(response) {
         }
         data_buf = lines[lines.length-1];
 
-        return reader.read().then(processResult);
-      });
+        return reader.read().then(processResult).catch(errorHandler);
+      }).catch(errorHandler);
 
     },
     cancel: function(reason) {


### PR DESCRIPTION
The upstream may throw error if unexpected things happened like lost connection
to server. Currently it is not catched which will is an uncatched promise
rejection. It will also make the stream stuck in not done state.

Related to https://github.com/canjs/can-ndjson-stream/issues/53